### PR TITLE
feat: L2 Resolver spec

### DIFF
--- a/docs/addresses/interoperable-onchain-chain-names.md
+++ b/docs/addresses/interoperable-onchain-chain-names.md
@@ -1,0 +1,44 @@
+# Issue l2.eth to Enable Chain-Specific Addresses
+
+# Intro
+
+Minting `l2.eth` (details below) will give ERC-7828 “Interoperable Addresses” a permanent home inside ENS via a future custom wildcard resolver. Today’s discussions concerns only the minting and transfer of the name.
+
+# Context
+
+The chain-specific-address initiative is driven by two complementary standards:
+
+- **ERC-7930** introduces a canonical binary format for *(chain, address)* pairs.
+- **ERC-7828** layers human-readable names on top of that binary format, allowing strings such as `alice.eth@rollupname.l2.eth#ABCD1234`.
+
+For ERC-7828 to work in a fully decentralized way, chain names themselves should live inside a reliable registry, such as ENS. Registering **`l2.eth`** gives the DAO a neutral namespace under which every L2 can publish its canonical name (e.g., `optimism.l2.eth ⇆ chainId 10`).
+
+# Approach
+
+There are two equally safe ways the DAO can register `l2.eth`, both already used for routine ENS maintenance:
+
+1. Use the DAO’s existing Controller wallet: This wallet already has permission to register `.eth` names, so it can claim `l2.eth` in a single transaction and hand it over to the multisig.
+2. Temporarily give the Owner wallet controller rights: The Owner wallet briefly grants itself permission, registers `l2.eth`, transfers the name to the multisig, and then removes its own permission. This keeps the long-standing Controller wallet untouched but adds one extra step.
+
+Regardless of which path we choose, the end-state is identical:
+
+- A multisig chosen by the DAO becomes the sole owner of `l2.eth`.
+- The multisig can later “wrap” the name for fine-grained permissions, set a wildcard resolver, and manage sub-names.
+
+For this temperature check, we focused on plan tu submit a proposal that mints `l2.eth` and transfers it to a new multisig. The resolver design, record format and first batch of chains will come back as a separate executable proposal once the name is safely in DAO hands.
+
+# Benefits
+
+Taking ownership of l2.eth does three very concrete things for ENS and for every wallet that relies on its service.
+
+First, it lets the two pending standards for Interoperable Addresses move from “nice idea” to “live feature.”  ERC-7930 already defines how to pack `(chain, address)` into bytes, and ERC-7828 defines how to turn that into text.  What they both lack is a guaranteed place to resolve the chain part.  `l2.eth` is that place.
+
+Second, it pretendes to replace the current off-chain JSON list of chain names with an on-chain registry that lives at `l2.eth` and is controlled by the DAO.  Right now, Optimism’s chain ID 10, Arbitrum One’s 42161, Base’s 8453, and hundreds of others sit in a GitHub repo that no contract can trust without manual vetting.  Once `optimism.l2.eth`, `arbitrum.l2.eth`, and `base.l2.eth` are recorded under a resolver the DAO governs, any smart contract or dApp can fetch that data directly from ENS
+Third, the wildcard resolver planned for `*.l2.eth` keeps scaling costs tiny.  The DAO registers the parent once; after that, adding a new roll-up means the multisig writes a single storage slot with the chain ID.
+
+# Next Steps
+
+1. Set up the multisig: Gather DAO feedback on signer selection and threshold (details to be finalized before the executable vote).
+2. Executable proposal: Specify the exact on-chain calls for the chosen registration path and list the multisig signers.
+3. Execution: Register `l2.eth`, then confirm that the multisig holds the name.
+4. Resolver development: A wildcard resolver, specified in the [L2Resolver spec](specs/addresses/L2Resolver.md), that resolves ENS chain names to their corresponding EIP-7930 chain identifiers, and vice versa.

--- a/docs/addresses/interoperable-onchain-chain-names.md
+++ b/docs/addresses/interoperable-onchain-chain-names.md
@@ -2,7 +2,8 @@
 
 # Intro
 
-Minting `l2.eth` (details below) will give ERC-7828 “Interoperable Addresses” a permanent home inside ENS via a future custom wildcard resolver. Today’s discussions concerns only the minting and transfer of the name.
+Minting `l2.eth` (details below) will give ERC-7828 “Interoperable Addresses” a permanent home inside ENS via a future custom wildcard resolver. This proposal has already been submitted as a temperature check to the ENS DAO and received a positive signal from the community.
+
 
 # Context
 
@@ -39,6 +40,6 @@ Third, the wildcard resolver planned for `*.l2.eth` keeps scaling costs tiny.  T
 # Next Steps
 
 1. Set up the multisig: Gather DAO feedback on signer selection and threshold (details to be finalized before the executable vote).
-2. Executable proposal: Specify the exact on-chain calls for the chosen registration path and list the multisig signers.
+2. Executable proposal: Specify the exact on-chain calls for the chosen registration path and list the multisig signers as per the [executable-proposal-template](https://github.com/ensdomains/docs/blob/master/src/public/governance/executable-proposal-template.md). Awaiting [new controller](https://github.com/ensdomains/ens-contracts/pull/438) to be production ready and approved by ENS DAO.
 3. Execution: Register `l2.eth`, then confirm that the multisig holds the name.
 4. Resolver development: A wildcard resolver, specified in the [L2Resolver spec](specs/addresses/L2Resolver.md), that resolves ENS chain names to their corresponding EIP-7930 chain identifiers, and vice versa.

--- a/docs/addresses/interoperable-onchain-chain-names.md
+++ b/docs/addresses/interoperable-onchain-chain-names.md
@@ -2,7 +2,7 @@
 
 # Intro
 
-Minting `l2.eth` (details below) will give ERC-7828 “Interoperable Addresses” a permanent home inside ENS via a future custom wildcard resolver. This proposal has already been submitted as a temperature check to the ENS DAO and received a positive signal from the community.
+Issuing `l2.eth` (details below) will give ERC-7828 “Interoperable Addresses” a permanent home inside ENS via a future custom wildcard resolver. This proposal has already been submitted as a temperature check to the ENS DAO and received a positive signal from the community.
 
 
 # Context
@@ -21,12 +21,14 @@ There are two equally safe ways the DAO can register `l2.eth`, both already used
 1. Use the DAO’s existing Controller wallet: This wallet already has permission to register `.eth` names, so it can claim `l2.eth` in a single transaction and hand it over to the multisig.
 2. Temporarily give the Owner wallet controller rights: The Owner wallet briefly grants itself permission, registers `l2.eth`, transfers the name to the multisig, and then removes its own permission. This keeps the long-standing Controller wallet untouched but adds one extra step.
 
+> **Upcoming option:** The [new controller](https://github.com/ensdomains/ens-contracts/pull/438) introduces a method called `registerWithoutPayment()` that can only be called by the DAO. It bypasses both the payment and the minimum character length requirement, enabling the DAO to register `l2.eth` directly once the update is live.
+
 Regardless of which path we choose, the end-state is identical:
 
 - A multisig chosen by the DAO becomes the sole owner of `l2.eth`.
 - The multisig can later “wrap” the name for fine-grained permissions, set a wildcard resolver, and manage sub-names.
 
-For this temperature check, we focused on plan tu submit a proposal that mints `l2.eth` and transfers it to a new multisig. The resolver design, record format and first batch of chains will come back as a separate executable proposal once the name is safely in DAO hands.
+For this temperature check, we focused on plan tu submit a proposal that issues `l2.eth` and transfers it to a new multisig. The resolver design, record format and first batch of chains will come back as a separate executable proposal once the name is safely in DAO hands.
 
 # Benefits
 
@@ -34,7 +36,8 @@ Taking ownership of l2.eth does three very concrete things for ENS and for every
 
 First, it lets the two pending standards for Interoperable Addresses move from “nice idea” to “live feature.”  ERC-7930 already defines how to pack `(chain, address)` into bytes, and ERC-7828 defines how to turn that into text.  What they both lack is a guaranteed place to resolve the chain part.  `l2.eth` is that place.
 
-Second, it pretendes to replace the current off-chain JSON list of chain names with an on-chain registry that lives at `l2.eth` and is controlled by the DAO.  Right now, Optimism’s chain ID 10, Arbitrum One’s 42161, Base’s 8453, and hundreds of others sit in a GitHub repo that no contract can trust without manual vetting.  Once `optimism.l2.eth`, `arbitrum.l2.eth`, and `base.l2.eth` are recorded under a resolver the DAO governs, any smart contract or dApp can fetch that data directly from ENS
+Second, it pretends to replace the current off-chain JSON list of chain names with an on-chain registry that lives at `l2.eth` and is controlled by the DAO.  Right now, Optimism’s chain ID 10, Arbitrum One’s 42161, Base’s 8453, and hundreds of others sit in a GitHub repo that no contract can trust without manual vetting.  Once `optimism.l2.eth`, `arbitrum.l2.eth`, and `base.l2.eth` are recorded under a resolver the DAO governs, any smart contract or dApp can fetch that data directly from ENS.
+
 Third, the wildcard resolver planned for `*.l2.eth` keeps scaling costs tiny.  The DAO registers the parent once; after that, adding a new roll-up means the multisig writes a single storage slot with the chain ID.
 
 # Next Steps

--- a/specs/addresses/L2Resolver.md
+++ b/specs/addresses/L2Resolver.md
@@ -4,7 +4,7 @@
 
 This document specifies a minimal L2 Resolver system for ENS. It focuses on resolving ENS names to their corresponding EIP-7930 formatted chain identifiers (as bytes) and resolving these EIP-7930 chain identifiers back to their primary ENS names. This system is implemented as a single contract that handles storage, authorization, and resolution logic.
 
-The system provides bidirectional resolution between ENS names (e.g., `optimism.l2.eth`) and EIP-7930 formatted chain identifiers, operating on the `l2.eth` 2LD (second-level domain) using ENSIP-10 wildcard resolution. The single `L2Resolver` contract contains storage via a `records` mapping, authorization logic following the ENS ownership model, and resolution functions including `resolveChainId()` for forward resolution and `resolveChainName()` for reverse resolution. Chain identifiers must use EIP-7930 format with `AddressLength = 0` (chain-only, no address component), and reverse lookups utilize a dedicated `REVERSE_LOOKUP_NODE` with keccak256-hashed keys.
+The system provides bidirectional resolution between ENS names (e.g., `optimism.l2.eth`) and EIP-7930 formatted chain identifiers, operating on the `l2.eth` 2LD (second-level domain) using ENSIP-10 wildcard resolution. The single `L2Resolver` contract contains storage via a `records` mapping, authorization logic following the ENS ownership model, and resolution functions including `chainId()` for forward resolution and `chainName()` for reverse resolution. Chain identifiers must use EIP-7930 format with `AddressLength = 0` (chain-only, no address component), and reverse lookups utilize a dedicated `REVERSE_LOOKUP_NODE` with keccak256-hashed keys.
 
 It is important to note that this resolver specification is primarily intended for consumption by off-chain clients, such as SDKs and wallet software, rather than for direct on-chain smart contract integrations.
 
@@ -26,8 +26,8 @@ This single-contract approach offers simplicity in initial deployment as all dat
 
 The primary functionalities of this L2 resolver system are:
 
-1. **Domain to Chain ID Resolution**: Given an ENS name (e.g., `optimism.l2.eth`), resolve its EIP-7930 formatted chain identifier as `bytes` (representing the chain only, with `AddressLength = 0`) via `resolveChainId`.
-2. **Chain ID to Domain Resolution**: Given an EIP-7930 formatted chain identifier as `bytes` (with `AddressLength = 0`), resolve its primary associated ENS name (e.g., `optimism.l2.eth`) via `resolveName`.
+1. **Domain to Chain ID Resolution**: Given an ENS name (e.g., `optimism.l2.eth`), resolve its EIP-7930 formatted chain identifier as `bytes` (representing the chain only, with `AddressLength = 0`) via `chainId`.
+2. **Chain ID to Domain Resolution**: Given an EIP-7930 formatted chain identifier as `bytes` (with `AddressLength = 0`), resolve its primary associated ENS name (e.g., `optimism.l2.eth`) via `chainName`.
 
 The L2 resolver system will operate on the designated ENS 2LD `l2.eth` using ENSIP-10 wildcard resolution. ENSIP-10 compliant clients, when resolving a name like `sub.l2.eth`, will first attempt to find a resolver for `sub.l2.eth`. If none is found, they will try the parent (`l2.eth`). If a resolver (this `L2Resolver` contract) is found for `l2.eth`, the client will then call the `resolve(bytes calldata name, bytes calldata data)` function on this resolver, passing the DNS-encoded original full name (e.g., `dnsencode("sub.l2.eth")`) as the `name` parameter.
 
@@ -61,11 +61,11 @@ This contract serves as the combined storage, authorization, and resolution laye
 - `function getRecord(bytes32 _node, string calldata _key) external view returns (bytes memory)`
     - Retrieves raw bytes for a given `node` and `key` from the `records` mapping. Returns empty `bytes` if the record is not found.
     
-- `function resolveChainId(bytes32 _node) external view returns (bytes memory)`
+- `function chainId(bytes32 _node) external view returns (bytes memory)`
     - Retrieves the EIP-7930 formatted chain identifier (as `bytes`, with `AddressLength = 0`) for a given `node`.
     - Implementation: Calls `this.getRecord(node, CHAIN_IDENTIFIER_EIP7930_KEY)`. Returns the raw `bytes` (which will be empty if the record is not found).
     
-- `function resolveChainName(bytes calldata _chainIdBytes) external view returns (string memory)`
+- `function chainName(bytes calldata _chainIdBytes) external view returns (string memory)`
     - Retrieves the primary human-readable ENS name string associated with a given EIP-7930 chain identifier (`bytes`, with `AddressLength = 0`).
     - Assumes the input `chainIdBytes` is a correctly formatted EIP-7930 sequence.
     - Off-chain tooling used to set reverse records should ensure canonical name formatting (e.g., lowercase, UTS#46 normalization) of the ENS name string.
@@ -83,11 +83,11 @@ This contract serves as the combined storage, authorization, and resolution laye
 - `function resolve(bytes calldata _name, bytes calldata _data) external view returns (bytes memory)`
     - Implements the ENSIP-10 Extended Resolver interface. This function is called by ENS clients when this contract serves as a wildcard resolver (e.g., for `.l2.eth`).
     - The `name` parameter is the DNS-encoded full version of the name being resolved (e.g., `dnsencode("optimism.l2.eth")`). This allows the resolver to inspect individual labels if needed for custom resolution logic beyond simple node-based lookups.
-    - The `data` parameter contains the ABI-encoded function selector and arguments for the actual data being requested, prepared by the client. For target functions that operate on an ENS node (like `resolveChainId(bytes32 node)`), the client calculates the `node` and includes it within this `data` payload.
+    - The `data` parameter contains the ABI-encoded function selector and arguments for the actual data being requested, prepared by the client. For target functions that operate on an ENS node (like `chainId(bytes32 node)`), the client calculates the `node` and includes it within this `data` payload.
     - This function routes calls to other specific view functions on this resolver based on the function selector found in the `data` parameter.
     - Currently supports routing to:
-        - `this.resolveChainId(node)`: If `data` contains the selector and ABI-encoded arguments for `resolveChainId(bytes32)`. The `node` argument is decoded by the resolver from the `data` parameter.
-        - `this.resolveName(chainIdentifierBytes)`: If `data` contains the selector and ABI-encoded arguments for `resolveName(bytes)`. The `chainIdentifierBytes` argument is decoded by the resolver from the `data` parameter.
+        - `this.chainId(node)`: If `data` contains the selector and ABI-encoded arguments for `chainId(bytes32)`. The `node` argument is decoded by the resolver from the `data` parameter.
+        - `this.chainName(chainIdentifierBytes)`: If `data` contains the selector and ABI-encoded arguments for `chainName(bytes)`. The `chainIdentifierBytes` argument is decoded by the resolver from the `data` parameter.
     - Returns the ABI-encoded result of the target function, or reverts if the `data` does not correspond to a supported function or if resolution fails.
 - `function supportsInterface(bytes4 interfaceID) external pure returns (bool)`
     - Implements ENSIP-165. Returns `true` for:

--- a/specs/addresses/L2Resolver.md
+++ b/specs/addresses/L2Resolver.md
@@ -1,0 +1,124 @@
+# Minimal L2 Resolver Specification
+
+## Overview
+
+This document specifies a minimal L2 Resolver system for ENS. It focuses on resolving ENS names to their corresponding EIP-7930 formatted chain identifiers (as bytes) and resolving these EIP-7930 chain identifiers back to their primary ENS names. This system is implemented as a single contract that handles storage, authorization, and resolution logic.
+
+The system provides bidirectional resolution between ENS names (e.g., `optimism.l2.eth`) and EIP-7930 formatted chain identifiers, operating on the `l2.eth` 2LD (second-level domain) using ENSIP-10 wildcard resolution. The single `L2Resolver` contract contains storage via a `records` mapping, authorization logic following the ENS ownership model, and resolution functions including `resolveChainId()` for forward resolution and `resolveChainName()` for reverse resolution. Chain identifiers must use EIP-7930 format with `AddressLength = 0` (chain-only, no address component), and reverse lookups utilize a dedicated `REVERSE_LOOKUP_NODE` with keccak256-hashed keys.
+
+It is important to note that this resolver specification is primarily intended for consumption by off-chain clients, such as SDKs and wallet software, rather than for direct on-chain smart contract integrations.
+
+---
+
+## Architecture
+
+The system comprises a single main smart contract:
+
+- **`L2Resolver`**: A contract that contains all data storage mechanisms, authorization logic for write operations, and the specific ENS resolution logic.
+
+### Design Considerations
+
+This single-contract approach offers simplicity in initial deployment as all data and logic are co-located. The storage structure and the initial set of functionalities are fixed upon deployment. This specification focuses on the self-contained L2Resolver contract. If further resolution paths or record types are desired, this contract can be wrapped by a newer one that extends the original interface. 
+
+---
+
+## Core Requirements
+
+The primary functionalities of this L2 resolver system are:
+
+1. **Domain to Chain ID Resolution**: Given an ENS name (e.g., `optimism.l2.eth`), resolve its EIP-7930 formatted chain identifier as `bytes` (representing the chain only, with `AddressLength = 0`) via `resolveChainId`.
+2. **Chain ID to Domain Resolution**: Given an EIP-7930 formatted chain identifier as `bytes` (with `AddressLength = 0`), resolve its primary associated ENS name (e.g., `optimism.l2.eth`) via `resolveName`.
+
+The L2 resolver system will operate on the designated ENS 2LD `l2.eth` using ENSIP-10 wildcard resolution. ENSIP-10 compliant clients, when resolving a name like `sub.l2.eth`, will first attempt to find a resolver for `sub.l2.eth`. If none is found, they will try the parent (`l2.eth`). If a resolver (this `L2Resolver` contract) is found for `l2.eth`, the client will then call the `resolve(bytes calldata name, bytes calldata data)` function on this resolver, passing the DNS-encoded original full name (e.g., `dnsencode("sub.l2.eth")`) as the `name` parameter.
+
+---
+
+## Contract Specification: `L2Resolver`
+
+This contract serves as the combined storage, authorization, and resolution layer.
+
+**State Variables:**
+
+- `mapping(bytes32 _node => mapping(string _key => bytes _data)) public records;`
+    - Stores arbitrary data for each ENS node.
+    - For domain-to-chain-identifier resolution, the `key` will be a pre-defined string (e.g., `CHAIN_IDENTIFIER_EIP7930_KEY`) and `data` will be the **raw EIP-7930 chain identifier `bytes`** (formatted with `AddressLength = 0`).
+    - For EIP-7930-chain-identifier-to-domain resolution (reverse lookup), the `REVERSE_LOOKUP_NODE` is used. The `key` is constructed by concatenating a prefix (e.g., `CHAIN_IDENTIFIER_EIP7930_KEY`) with the hexadecimal string representation of the `keccak256` hash of the EIP-7930 chain identifier `bytes`. The `data` stored is the **ABI-encoded human-readable ENS name string** (e.g., `abi.encode("optimism.l2.eth")`).
+
+**Constants:**
+
+- `bytes32 constant REVERSE_LOOKUP_NODE = bytes32(keccak256("reverse.chain.id.eip7930"));`
+    - A dedicated node hash for storing reverse lookup entries within this contract's `records` mapping.
+- `string constant CHAIN_IDENTIFIER_EIP7930_KEY = "chain.id.eip7930";`
+    - The key used in `records` to store the EIP-7930 chain identifier bytes for a forward resolution.
+
+**Key Functions:**
+
+- `function setRecord(bytes32 _node, string calldata _key, bytes calldata _value) external /* authorized */`
+    - Sets raw bytes for a given `node` and `key` in the `records` mapping.
+    - Authorization logic is implemented directly within this function (see below).
+    - Emits: `RecordSet(bytes32 indexed _node, string indexed _key, bytes _value)`
+    
+- `function getRecord(bytes32 _node, string calldata _key) external view returns (bytes memory)`
+    - Retrieves raw bytes for a given `node` and `key` from the `records` mapping. Returns empty `bytes` if the record is not found.
+    
+- `function resolveChainId(bytes32 _node) external view returns (bytes memory)`
+    - Retrieves the EIP-7930 formatted chain identifier (as `bytes`, with `AddressLength = 0`) for a given `node`.
+    - Implementation: Calls `this.getRecord(node, CHAIN_IDENTIFIER_EIP7930_KEY)`. Returns the raw `bytes` (which will be empty if the record is not found).
+    
+- `function resolveChainName(bytes calldata _chainIdBytes) external view returns (string memory)`
+    - Retrieves the primary human-readable ENS name string associated with a given EIP-7930 chain identifier (`bytes`, with `AddressLength = 0`).
+    - Assumes the input `chainIdBytes` is a correctly formatted EIP-7930 sequence.
+    - Off-chain tooling used to set reverse records should ensure canonical name formatting (e.g., lowercase, UTS#46 normalization) of the ENS name string.
+    - Implementation:
+        1. Hash the input: `bytes32 identifierHash = keccak256(chainIdBytes);`
+        2. Convert hash to hex string (conceptual step, e.g., using an internal `_bytes32ToHexString` helper). Let this be `hexIdentifierHash`.
+        3. Construct key: `string memory key = string.concat(CHAIN_IDENTIFIER_EIP7930_KEY, hexIdentifierHash);`
+        4. Retrieves data: `bytes memory data = this.getRecord(REVERSE_LOOKUP_NODE, key);`
+        5. Handles not found: `if (data.length == 0) { return ""; }`
+        6. Decodes and returns: `return abi.decode(data, (string));` (This will revert if `data` is not a valid ABI-encoded string).
+        
+
+**ENS Standard Functions:**
+
+- `function resolve(bytes calldata _name, bytes calldata _data) external view returns (bytes memory)`
+    - Implements the ENSIP-10 Extended Resolver interface. This function is called by ENS clients when this contract serves as a wildcard resolver (e.g., for `.l2.eth`).
+    - The `name` parameter is the DNS-encoded full version of the name being resolved (e.g., `dnsencode("optimism.l2.eth")`). This allows the resolver to inspect individual labels if needed for custom resolution logic beyond simple node-based lookups.
+    - The `data` parameter contains the ABI-encoded function selector and arguments for the actual data being requested, prepared by the client. For target functions that operate on an ENS node (like `resolveChainId(bytes32 node)`), the client calculates the `node` and includes it within this `data` payload.
+    - This function routes calls to other specific view functions on this resolver based on the function selector found in the `data` parameter.
+    - Currently supports routing to:
+        - `this.resolveChainId(node)`: If `data` contains the selector and ABI-encoded arguments for `resolveChainId(bytes32)`. The `node` argument is decoded by the resolver from the `data` parameter.
+        - `this.resolveName(chainIdentifierBytes)`: If `data` contains the selector and ABI-encoded arguments for `resolveName(bytes)`. The `chainIdentifierBytes` argument is decoded by the resolver from the `data` parameter.
+    - Returns the ABI-encoded result of the target function, or reverts if the `data` does not correspond to a supported function or if resolution fails.
+- `function supportsInterface(bytes4 interfaceID) external pure returns (bool)`
+    - Implements ENSIP-165. Returns `true` for:
+        - `0x01ffc9a7` (IERC165)
+        - `0x9061b923` (ENSIP-10 ExtendedResolver interface)
+
+---
+
+## EIP-7930 Chain Identifier Format
+
+Chain identifiers are stored and retrieved as EIP-7930 binary formatted `bytes`. For the purpose of this resolver (identifying a chain, not an address on a chain), these identifiers **MUST** be formatted with `AddressLength = 0`.
+
+The basic structure as per EIP-7930 v1 is:
+`Version (2 bytes) | ChainType (2 bytes) | ChainReferenceLength (1 byte) | ChainReference (variable) | AddressLength (1 byte, value 0x00)`
+
+- **Version**: `0x0001` (for v1).
+- **ChainType**: As defined in CAIP-350 (corresponds to a CAIP-2 namespace).
+- **ChainReferenceLength**: Length of `ChainReference`.
+- **ChainReference**: Binary representation of the chain ID within the `ChainType`'s namespace.
+- **AddressLength**: `0x00` (1 byte, value zero), indicating no address part.
+
+Clients (SDKs, wallets) interacting with this resolver are responsible for correctly constructing and parsing these EIP-7930 chain identifier `bytes`. The resolver contract treats this data as opaque byte sequences for storage and retrieval in forward lookups, and uses its hash for keying in reverse lookups.
+
+---
+
+## Authorization Model
+
+Write operations via `setRecord(bytes32 node, string calldata key, bytes calldata value)` must be permissioned. The authorization logic is implemented directly within the `L2Resolver` contract. It should generally follow the ENS ownership model:
+
+- To set a record for a specific `node` (e.g., `namehash("optimism.l2.eth")`), `msg.sender` must be the beneficial owner of that `node` (potentially resolved via `ENS.owner(node)` and checking against `INameWrapper.ownerOf(node)` if applicable) or an operator approved by the beneficial owner.
+- For non-registered 3LDs (wildcard scenario where `node` corresponds to something like `namehash("unregistered.l2.eth")`), `msg.sender` must be the beneficial owner of the parent domain (e.g., `l2.eth`) or their approved operator.
+- To set a reverse EIP-7930 chain identifier mapping (i.e., when `node == REVERSE_LOOKUP_NODE`), `msg.sender` must be a designated administrative entity (e.g., the owner of `l2.eth` or a specific authorized address). This control for `REVERSE_LOOKUP_NODE` writes is crucial for the integrity of reverse lookups.
+
+The `L2Resolver` will require a reference to the ENS Registry (and potentially INameWrapper) to implement this authorization logic.


### PR DESCRIPTION
Add L2Resolver spec for ERC-7828

- Defines how l2.eth chain names and identifiers are resolved and integrated with Interoperable Addresses. 