### PR TITLE
docs: interop addr compatibility

### DIFF
--- a/docs/addresses/interoperable-addresses-CAIP10-DID-compatibility.md
+++ b/docs/addresses/interoperable-addresses-CAIP10-DID-compatibility.md
@@ -1,0 +1,128 @@
+# ERC-7930 & ERC-7828: CAIP-10 and DID Compatibility
+
+This document analyzes the compatibility between ERC-7930 (binary interoperable addresses) and ERC-7828 (human readable addresses) with existing standards CAIP-10 and W3C Decentralized Identifiers (DID). While these standards share similar goals, they have compatibility challenges to consider.
+
+## TL;DR
+
+**ERC-7930 & CAIP-10 Compatibility:**
+
+ERC-7828/7930 is fully compatible with CAIP-10, as it uses the same core fields: `address` and `chainId`. While ERC-7930 uses `@` as a separator for readability (`address@chain`), this can be safely percent-encoded as `%40` to comply with CAIP-10’s character restrictions. Since the data structure is equivalent, conversion between formats is trivial, making ERC-7930 fully interoperable with CAIP-10.
+
+**ERC-7928/7930 & DID Compatibility:**
+
+Although ERC-7828/7930 lack a formal DID method (analogous to not having a resolver in ENS), they are compatible with the W3C DID standard. They ensure globally unique, permissionless, and verifiable identifiers via `address + chainId`, satisfying the core DID requirements. Once a formal DID method is specified, ERC-7930 would be fully DID-compliant.
+
+## CAIP-10 Compatibility
+
+ERC-7930 builds upon the foundation of CAIP-10's string based account identifier (`<chain_id>:<address>`) by introducing a more robust, dual format system. It defines a compact, length prefixed **binary envelope** designed for on chain efficiency, capable of carrying any `(chain ID, address)` pair regardless of byte length or cryptographic system. This is paired with a human readable string, `address@chain`, which contains the exact same information as CAIP-10. Because the core data is identical, conversion between the two formats is a trivial process of reordering the elements and swapping the separator (`@` ↔ `:`). This ensures that any ERC-7930 address can be seamlessly expressed as a valid CAIP-10 ID and viceversa, while also gaining ERC-7930's critical advantages: a canonical binary format for smart contracts, guaranteed future extensibility and namespace flexibility.
+
+### 1. The Chain ID Length Problem
+
+The most significant point of incompatibility arises from the constraints on chain identifier length. CAIP-10 leverages **CAIP-2**, which formally limits the `reference` portion of a chain ID to a **maximum of 32 characters** composed of `[a-zA-Z0-9]`. This design was based on practical assumptions from when the standard was written, for example, many early chain profiles, especially for UTXO based chains like Bitcoin, expected identifiers no longer than 16 bytes (32 hex characters). Consequently, many applications built around CAIP-10 assumed reasonably short chain IDs.
+
+In contrast, ERC-7930 was explicitly designed to be future-proof and **does not impose any limit on chain ID size**, allowing it to natively support full 256-bit (32 byte) identifiers in its binary format. This foresight is critical for emerging standards like **ERC-7785**, which proposes using a `keccak256` hash of a chain's name to create a collision resistant ID. Such a hash is 32 bytes long, and its hexadecimal string representation is 64 characters long (plus `0x`).
+
+This creates a direct conflict: a 64-character hash string cannot be stored in a 32-character field. In CAIP-2 terms, there’s no clear or standard way to truncate a 32 byte hash into a 32-character reference without breaking the specification and losing the guarantee of uniqueness**.** ERC-7930 gracefully handles this, while CAIP-10's format cannot.
+
+### **Example 1: The CAIP-2 Limit**
+
+```
+// CAIP-2 Chain Reference: Maximum 32 characters.
+// A real-world example is Bitcoin, whose `reference` is a 32-character hex string.
+bip122:000000000019d6689c085ae165831e93:1A1z...
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        Exactly 32 characters, matching the limit.
+
+```
+
+### **Example 2: The ERC-7785 Problem**
+
+```
+// ERC-7785 uses keccak256 for chain IDs. Hashes are 32 bytes long.
+bytes32 chainIdHash = keccak256("arbitrum-nova-zk-rollup-2025");
+
+// The hexadecimal string representation of a 32-byte hash is 64 characters long.
+// Result: 0x59a35e1b33e2842d416b2e1a3a6971ce181d2da2834655f2b322a36b33b23e1b
+//         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+//         64 characters - Far exceeds CAIP-10's 32-character limit.
+
+```
+
+### **Example 3: The ERC-7930 Solution**
+
+```
+// ERC-7930's binary format natively supports full 256-bit (32-byte) chain IDs.
+// Using the same hash from the problem above, the binary payload would be structured as:
+
+0x000100002059a35e1b33e2842d416b2e1a3a6971ce181d2da2834655f2b322a36b33b23e1b...
+// │  │   │ └─ ChainReference: The full 32-byte keccak256 hash
+// │  │   └─ ChainRefLen: 32 bytes (0x20)
+// │  └─ ChainType: eip155 (0x0000)
+// └─ Version: 1 (0x0001)
+
+```
+
+### 2. Field Order and Separator **(`address@chain` vs `chain:address`)**
+
+ERC-7930’s human format puts the address first and chain second (using `@`), whereas CAIP-10 puts the chain first (using `:`). T**his difference is purely superficial,** there is no ambiguity or loss of information, it’s simply a reversed order. In practice, this does not cause problems in conversion.
+
+ A parser can easily detect the `@` in an ERC-7930 string and flip the order to produce `chain:address` (CAIP-10) or vice versa.  As long as libraries are aware of both formats, **bidirectional conversion is trivial**. The choice of `@` was likely made to improve human readability (it mimics email addresses like `user@domain`)  but it doesn’t conflict with the CAIP-10 meaning.
+
+**CAIP-10 Order:**
+
+```
+chain:address
+eip155:1:0xab16a96D359eC26a11e2C2b3d8f8B8942d5Bfcdb
+
+```
+
+**ERC-7828 Order:**
+
+```
+address@chain#checksum
+alice.eth@ethereum#ABC123
+
+```
+
+### 3. Special Character Handling
+
+ERC-7930 is flexible in that the chain and address fields can be arbitrary binary data (the binary format even allows lengths of zero for certain fields in special cases). However, CAIP-10 account IDs are plain text strings intended for use in URIs/URLs, which means **only a limited set of characters are allowed** (letters, digits, `:`, `-`, and `%` , essentially the URL safe character set). If an address or chain ID in ERC-7930 contains bytes outside the URL safe range, we need a way to represent those bytes in the CAIP-10 string. The solution is standard **percent encoding**. ERC-7930’s text format explicitly permits the `%` character so that any byte value can be hex encoded as `%XX`. This is analogous to how URLs encode special characters or binary data as `%20`, `%3A`, etc. (per [RFC 3986](https://www.rfc-editor.org/rfc/rfc3986)).   URL percent encoding is the standard method to include “arbitrary data in a URI using only the US-ASCII characters legal within a URI”. ERC-7930 basically builds this capability in by allowing `%` in its text syntax.
+
+```
+Original ERC-7828: alice.eth@ethereum#ABC123
+URL Encoded:      alice.eth%40ethereum%23ABC123
+CAIP-10 Format:   eip155:1:alice.eth%40ethereum%23ABC123
+```
+
+## DID Compatibility Analysis
+
+The potential for ERC-7930/7828 to serve as a basis for Decentralized Identifiers (DIDs) hinges on its alignment with the core tenets of the W3C standard. This framework requires any identifier to be globally unique, cryptographically verifiable, and created without reliance on a central authority. Crucially, a DID must also be resolvable to a **DID Document** a machine readable file containing its public keys and metadata. With these principles as our benchmark, we can analyze the inherent capabilities and current limitations of the ERC-7930/7828 standards. The following analysis examines how ERC-7930/7828 perform against each of these key requirements:
+
+- **Globally Unique Identifier:** By pairing a specific chain ID with a unique account address, ERC-7930 creates a globally unique identifier. This follows the same proven principle as CAIP-10 and is a core requirement for any DID method.
+- **No Central Registry Required:**  An address is constructed from public chain data and a user-generated key, making its creation permissionless and free from any central registry. The core address functions independently, aligning with the DID goal of avoiding centralized issuance.  A nuance exists with ERC-7828's use of ENS names, which introduces a dependency on the ENS registry itself, though ENS is a decentralized system.
+- **Cryptographically Verifiable:** Control is proven by signing a message with the private key tied to the address. The standard is built on top of native blockchain accounts and simply inherits their strong built in verifiability.
+- **Resolvable to a DID Document:**  This is the one missing piece. ERC-7930 defines the **identifier format**, but does not yet specify a **DID Method**—the standardized process for resolving that identifier into a DID Document. It is "DID-ready" but requires a formal method specification to become fully DID-complete.
+
+## **The Role of CAIP-350**
+
+We've seen that ERC-7930 provides a flexible binary format for addresses. But a critical question remains: if the format is generic, how does a wallet or application know what the bytes in the `ChainReference` and `Address` fields actually represent for a *specific* blockchain? An Ethereum address is structured differently from a Bitcoin or Solana address.
+
+This is the problem that **CAIP-350** solves. It acts as a companion standard to ERC-7930, defining the precise serialization rules for different chain families.
+
+- **ERC-7930 defines the *envelope*:** It specifies a generic binary structure:
+    
+    `Version | ChainType | ChainReferenceLength | ChainReference | AddressLength | Address`. 
+    It provides the universal container but is agnostic about its contents.
+    
+- **CAIP-350 defines the *contents*:** It tells you *what* the data inside the envelope means for a specific chain type (namespace).
+
+Essentially, **ERC-7930 is the box, and CAIP-350 is the set of instructions for what to put in the box and how to pack it**. This modularity allows ERC-7930 to support any new blockchain without changing the ERC-7930 standard itself, you just need to create a new CAIP-350 profile for that new chain.
+
+**Is CAIP-50 compatible with CAIP-350?**
+
+CAIP-50 is a *predecessor* and a different approach to what CAIP-350 and ERC-7930 are trying to solve. They are **not compatible** because they embody fundamentally different design philosophies.
+
+- **CAIP-50 (monolithic):** Defines a *self-contained, all-in-one* binary format using multicodec. Everything, including the multicodec identifier (`0xca`), namespace codes, lengths, and data, is concatenated into a single byte array and then base58-encoded. It's a complete, standalone specification.
+- **CAIP-350 + ERC-7930 (modular):** Separates the container from its contents. ERC-7930 defines the *outer structure* (the envelope)  while CAIP-350 defines the *inner serialization rules* for each chain type.
+
+They are incompatible because a CAIP-50 parser would not understand an ERC-7930 binary object, and vice-versa.

--- a/docs/addresses/interoperable-onchain-chain-names.md
+++ b/docs/addresses/interoperable-onchain-chain-names.md
@@ -1,0 +1,44 @@
+# Issue l2.eth to Enable Chain-Specific Addresses
+
+# Intro
+
+Minting `l2.eth` (details below) will give ERC-7828 “Interoperable Addresses” a permanent home inside ENS via a future custom wildcard resolver. Today’s discussions concerns only the minting and transfer of the name.
+
+# Context
+
+The chain-specific-address initiative is driven by two complementary standards:
+
+- **ERC-7930** introduces a canonical binary format for *(chain, address)* pairs.
+- **ERC-7828** layers human-readable names on top of that binary format, allowing strings such as `alice.eth@rollupname.l2.eth#ABCD1234`.
+
+For ERC-7828 to work in a fully decentralized way, chain names themselves should live inside a reliable registry, such as ENS. Registering **`l2.eth`** gives the DAO a neutral namespace under which every L2 can publish its canonical name (e.g., `optimism.l2.eth ⇆ chainId 10`).
+
+# Approach
+
+There are two equally safe ways the DAO can register `l2.eth`, both already used for routine ENS maintenance:
+
+1. Use the DAO’s existing Controller wallet: This wallet already has permission to register `.eth` names, so it can claim `l2.eth` in a single transaction and hand it over to the multisig.
+2. Temporarily give the Owner wallet controller rights: The Owner wallet briefly grants itself permission, registers `l2.eth`, transfers the name to the multisig, and then removes its own permission. This keeps the long-standing Controller wallet untouched but adds one extra step.
+
+Regardless of which path we choose, the end-state is identical:
+
+- A multisig chosen by the DAO becomes the sole owner of `l2.eth`.
+- The multisig can later “wrap” the name for fine-grained permissions, set a wildcard resolver, and manage sub-names.
+
+For this temperature check, we focused on plan tu submit a proposal that mints `l2.eth` and transfers it to a new multisig. The resolver design, record format and first batch of chains will come back as a separate executable proposal once the name is safely in DAO hands.
+
+# Benefits
+
+Taking ownership of l2.eth does three very concrete things for ENS and for every wallet that relies on its service.
+
+First, it lets the two pending standards for Interoperable Addresses move from “nice idea” to “live feature.”  ERC-7930 already defines how to pack `(chain, address)` into bytes, and ERC-7828 defines how to turn that into text.  What they both lack is a guaranteed place to resolve the chain part.  `l2.eth` is that place.
+
+Second, it pretendes to replace the current off-chain JSON list of chain names with an on-chain registry that lives at `l2.eth` and is controlled by the DAO.  Right now, Optimism’s chain ID 10, Arbitrum One’s 42161, Base’s 8453, and hundreds of others sit in a GitHub repo that no contract can trust without manual vetting.  Once `optimism.l2.eth`, `arbitrum.l2.eth`, and `base.l2.eth` are recorded under a resolver the DAO governs, any smart contract or dApp can fetch that data directly from ENS
+Third, the wildcard resolver planned for `*.l2.eth` keeps scaling costs tiny.  The DAO registers the parent once; after that, adding a new roll-up means the multisig writes a single storage slot with the chain ID.
+
+# Next Steps
+
+1. Set up the multisig: Gather DAO feedback on signer selection and threshold (details to be finalized before the executable vote).
+2. Executable proposal: Specify the exact on-chain calls for the chosen registration path and list the multisig signers.
+3. Execution: Register `l2.eth`, then confirm that the multisig holds the name.
+4. Resolver development: A wildcard resolver, specified in the [L2Resolver spec](specs/addresses/L2Resolver.md), that resolves ENS chain names to their corresponding EIP-7930 chain identifiers, and vice versa.

--- a/docs/addresses/interoperable-onchain-chain-names.md
+++ b/docs/addresses/interoperable-onchain-chain-names.md
@@ -2,7 +2,8 @@
 
 # Intro
 
-Minting `l2.eth` (details below) will give ERC-7828 “Interoperable Addresses” a permanent home inside ENS via a future custom wildcard resolver. Today’s discussions concerns only the minting and transfer of the name.
+Minting `l2.eth` (details below) will give ERC-7828 “Interoperable Addresses” a permanent home inside ENS via a future custom wildcard resolver. This proposal has already been submitted as a temperature check to the ENS DAO and received a positive signal from the community.
+
 
 # Context
 
@@ -39,6 +40,6 @@ Third, the wildcard resolver planned for `*.l2.eth` keeps scaling costs tiny.  T
 # Next Steps
 
 1. Set up the multisig: Gather DAO feedback on signer selection and threshold (details to be finalized before the executable vote).
-2. Executable proposal: Specify the exact on-chain calls for the chosen registration path and list the multisig signers.
+2. Executable proposal: Specify the exact on-chain calls for the chosen registration path and list the multisig signers as per the [executable-proposal-template](https://github.com/ensdomains/docs/blob/master/src/public/governance/executable-proposal-template.md). Awaiting [new controller](https://github.com/ensdomains/ens-contracts/pull/438) to be production ready and approved by ENS DAO.
 3. Execution: Register `l2.eth`, then confirm that the multisig holds the name.
 4. Resolver development: A wildcard resolver, specified in the [L2Resolver spec](specs/addresses/L2Resolver.md), that resolves ENS chain names to their corresponding EIP-7930 chain identifiers, and vice versa.

--- a/docs/addresses/interoperable-onchain-chain-names.md
+++ b/docs/addresses/interoperable-onchain-chain-names.md
@@ -2,7 +2,7 @@
 
 # Intro
 
-Minting `l2.eth` (details below) will give ERC-7828 “Interoperable Addresses” a permanent home inside ENS via a future custom wildcard resolver. This proposal has already been submitted as a temperature check to the ENS DAO and received a positive signal from the community.
+Issuing `l2.eth` (details below) will give ERC-7828 “Interoperable Addresses” a permanent home inside ENS via a future custom wildcard resolver. This proposal has already been submitted as a temperature check to the ENS DAO and received a positive signal from the community.
 
 
 # Context
@@ -21,12 +21,14 @@ There are two equally safe ways the DAO can register `l2.eth`, both already used
 1. Use the DAO’s existing Controller wallet: This wallet already has permission to register `.eth` names, so it can claim `l2.eth` in a single transaction and hand it over to the multisig.
 2. Temporarily give the Owner wallet controller rights: The Owner wallet briefly grants itself permission, registers `l2.eth`, transfers the name to the multisig, and then removes its own permission. This keeps the long-standing Controller wallet untouched but adds one extra step.
 
+> **Upcoming option:** The [new controller](https://github.com/ensdomains/ens-contracts/pull/438) introduces a method called `registerWithoutPayment()` that can only be called by the DAO. It bypasses both the payment and the minimum character length requirement, enabling the DAO to register `l2.eth` directly once the update is live.
+
 Regardless of which path we choose, the end-state is identical:
 
 - A multisig chosen by the DAO becomes the sole owner of `l2.eth`.
 - The multisig can later “wrap” the name for fine-grained permissions, set a wildcard resolver, and manage sub-names.
 
-For this temperature check, we focused on plan tu submit a proposal that mints `l2.eth` and transfers it to a new multisig. The resolver design, record format and first batch of chains will come back as a separate executable proposal once the name is safely in DAO hands.
+For this temperature check, we focused on plan tu submit a proposal that issues `l2.eth` and transfers it to a new multisig. The resolver design, record format and first batch of chains will come back as a separate executable proposal once the name is safely in DAO hands.
 
 # Benefits
 
@@ -34,7 +36,8 @@ Taking ownership of l2.eth does three very concrete things for ENS and for every
 
 First, it lets the two pending standards for Interoperable Addresses move from “nice idea” to “live feature.”  ERC-7930 already defines how to pack `(chain, address)` into bytes, and ERC-7828 defines how to turn that into text.  What they both lack is a guaranteed place to resolve the chain part.  `l2.eth` is that place.
 
-Second, it pretendes to replace the current off-chain JSON list of chain names with an on-chain registry that lives at `l2.eth` and is controlled by the DAO.  Right now, Optimism’s chain ID 10, Arbitrum One’s 42161, Base’s 8453, and hundreds of others sit in a GitHub repo that no contract can trust without manual vetting.  Once `optimism.l2.eth`, `arbitrum.l2.eth`, and `base.l2.eth` are recorded under a resolver the DAO governs, any smart contract or dApp can fetch that data directly from ENS
+Second, it pretends to replace the current off-chain JSON list of chain names with an on-chain registry that lives at `l2.eth` and is controlled by the DAO.  Right now, Optimism’s chain ID 10, Arbitrum One’s 42161, Base’s 8453, and hundreds of others sit in a GitHub repo that no contract can trust without manual vetting.  Once `optimism.l2.eth`, `arbitrum.l2.eth`, and `base.l2.eth` are recorded under a resolver the DAO governs, any smart contract or dApp can fetch that data directly from ENS.
+
 Third, the wildcard resolver planned for `*.l2.eth` keeps scaling costs tiny.  The DAO registers the parent once; after that, adding a new roll-up means the multisig writes a single storage slot with the chain ID.
 
 # Next Steps

--- a/specs/addresses/L2Resolver.md
+++ b/specs/addresses/L2Resolver.md
@@ -4,7 +4,7 @@
 
 This document specifies a minimal L2 Resolver system for ENS. It focuses on resolving ENS names to their corresponding EIP-7930 formatted chain identifiers (as bytes) and resolving these EIP-7930 chain identifiers back to their primary ENS names. This system is implemented as a single contract that handles storage, authorization, and resolution logic.
 
-The system provides bidirectional resolution between ENS names (e.g., `optimism.l2.eth`) and EIP-7930 formatted chain identifiers, operating on the `l2.eth` 2LD (second-level domain) using ENSIP-10 wildcard resolution. The single `L2Resolver` contract contains storage via a `records` mapping, authorization logic following the ENS ownership model, and resolution functions including `resolveChainId()` for forward resolution and `resolveChainName()` for reverse resolution. Chain identifiers must use EIP-7930 format with `AddressLength = 0` (chain-only, no address component), and reverse lookups utilize a dedicated `REVERSE_LOOKUP_NODE` with keccak256-hashed keys.
+The system provides bidirectional resolution between ENS names (e.g., `optimism.l2.eth`) and EIP-7930 formatted chain identifiers, operating on the `l2.eth` 2LD (second-level domain) using ENSIP-10 wildcard resolution. The single `L2Resolver` contract contains storage via a `records` mapping, authorization logic following the ENS ownership model, and resolution functions including `chainId()` for forward resolution and `chainName()` for reverse resolution. Chain identifiers must use EIP-7930 format with `AddressLength = 0` (chain-only, no address component), and reverse lookups utilize a dedicated `REVERSE_LOOKUP_NODE` with keccak256-hashed keys.
 
 It is important to note that this resolver specification is primarily intended for consumption by off-chain clients, such as SDKs and wallet software, rather than for direct on-chain smart contract integrations.
 
@@ -26,8 +26,8 @@ This single-contract approach offers simplicity in initial deployment as all dat
 
 The primary functionalities of this L2 resolver system are:
 
-1. **Domain to Chain ID Resolution**: Given an ENS name (e.g., `optimism.l2.eth`), resolve its EIP-7930 formatted chain identifier as `bytes` (representing the chain only, with `AddressLength = 0`) via `resolveChainId`.
-2. **Chain ID to Domain Resolution**: Given an EIP-7930 formatted chain identifier as `bytes` (with `AddressLength = 0`), resolve its primary associated ENS name (e.g., `optimism.l2.eth`) via `resolveName`.
+1. **Domain to Chain ID Resolution**: Given an ENS name (e.g., `optimism.l2.eth`), resolve its EIP-7930 formatted chain identifier as `bytes` (representing the chain only, with `AddressLength = 0`) via `chainId`.
+2. **Chain ID to Domain Resolution**: Given an EIP-7930 formatted chain identifier as `bytes` (with `AddressLength = 0`), resolve its primary associated ENS name (e.g., `optimism.l2.eth`) via `chainName`.
 
 The L2 resolver system will operate on the designated ENS 2LD `l2.eth` using ENSIP-10 wildcard resolution. ENSIP-10 compliant clients, when resolving a name like `sub.l2.eth`, will first attempt to find a resolver for `sub.l2.eth`. If none is found, they will try the parent (`l2.eth`). If a resolver (this `L2Resolver` contract) is found for `l2.eth`, the client will then call the `resolve(bytes calldata name, bytes calldata data)` function on this resolver, passing the DNS-encoded original full name (e.g., `dnsencode("sub.l2.eth")`) as the `name` parameter.
 
@@ -61,11 +61,11 @@ This contract serves as the combined storage, authorization, and resolution laye
 - `function getRecord(bytes32 _node, string calldata _key) external view returns (bytes memory)`
     - Retrieves raw bytes for a given `node` and `key` from the `records` mapping. Returns empty `bytes` if the record is not found.
     
-- `function resolveChainId(bytes32 _node) external view returns (bytes memory)`
+- `function chainId(bytes32 _node) external view returns (bytes memory)`
     - Retrieves the EIP-7930 formatted chain identifier (as `bytes`, with `AddressLength = 0`) for a given `node`.
     - Implementation: Calls `this.getRecord(node, CHAIN_IDENTIFIER_EIP7930_KEY)`. Returns the raw `bytes` (which will be empty if the record is not found).
     
-- `function resolveChainName(bytes calldata _chainIdBytes) external view returns (string memory)`
+- `function chainName(bytes calldata _chainIdBytes) external view returns (string memory)`
     - Retrieves the primary human-readable ENS name string associated with a given EIP-7930 chain identifier (`bytes`, with `AddressLength = 0`).
     - Assumes the input `chainIdBytes` is a correctly formatted EIP-7930 sequence.
     - Off-chain tooling used to set reverse records should ensure canonical name formatting (e.g., lowercase, UTS#46 normalization) of the ENS name string.
@@ -83,11 +83,11 @@ This contract serves as the combined storage, authorization, and resolution laye
 - `function resolve(bytes calldata _name, bytes calldata _data) external view returns (bytes memory)`
     - Implements the ENSIP-10 Extended Resolver interface. This function is called by ENS clients when this contract serves as a wildcard resolver (e.g., for `.l2.eth`).
     - The `name` parameter is the DNS-encoded full version of the name being resolved (e.g., `dnsencode("optimism.l2.eth")`). This allows the resolver to inspect individual labels if needed for custom resolution logic beyond simple node-based lookups.
-    - The `data` parameter contains the ABI-encoded function selector and arguments for the actual data being requested, prepared by the client. For target functions that operate on an ENS node (like `resolveChainId(bytes32 node)`), the client calculates the `node` and includes it within this `data` payload.
+    - The `data` parameter contains the ABI-encoded function selector and arguments for the actual data being requested, prepared by the client. For target functions that operate on an ENS node (like `chainId(bytes32 node)`), the client calculates the `node` and includes it within this `data` payload.
     - This function routes calls to other specific view functions on this resolver based on the function selector found in the `data` parameter.
     - Currently supports routing to:
-        - `this.resolveChainId(node)`: If `data` contains the selector and ABI-encoded arguments for `resolveChainId(bytes32)`. The `node` argument is decoded by the resolver from the `data` parameter.
-        - `this.resolveName(chainIdentifierBytes)`: If `data` contains the selector and ABI-encoded arguments for `resolveName(bytes)`. The `chainIdentifierBytes` argument is decoded by the resolver from the `data` parameter.
+        - `this.chainId(node)`: If `data` contains the selector and ABI-encoded arguments for `chainId(bytes32)`. The `node` argument is decoded by the resolver from the `data` parameter.
+        - `this.chainName(chainIdentifierBytes)`: If `data` contains the selector and ABI-encoded arguments for `chainName(bytes)`. The `chainIdentifierBytes` argument is decoded by the resolver from the `data` parameter.
     - Returns the ABI-encoded result of the target function, or reverts if the `data` does not correspond to a supported function or if resolution fails.
 - `function supportsInterface(bytes4 interfaceID) external pure returns (bool)`
     - Implements ENSIP-165. Returns `true` for:

--- a/specs/addresses/L2Resolver.md
+++ b/specs/addresses/L2Resolver.md
@@ -1,0 +1,124 @@
+# Minimal L2 Resolver Specification
+
+## Overview
+
+This document specifies a minimal L2 Resolver system for ENS. It focuses on resolving ENS names to their corresponding EIP-7930 formatted chain identifiers (as bytes) and resolving these EIP-7930 chain identifiers back to their primary ENS names. This system is implemented as a single contract that handles storage, authorization, and resolution logic.
+
+The system provides bidirectional resolution between ENS names (e.g., `optimism.l2.eth`) and EIP-7930 formatted chain identifiers, operating on the `l2.eth` 2LD (second-level domain) using ENSIP-10 wildcard resolution. The single `L2Resolver` contract contains storage via a `records` mapping, authorization logic following the ENS ownership model, and resolution functions including `resolveChainId()` for forward resolution and `resolveChainName()` for reverse resolution. Chain identifiers must use EIP-7930 format with `AddressLength = 0` (chain-only, no address component), and reverse lookups utilize a dedicated `REVERSE_LOOKUP_NODE` with keccak256-hashed keys.
+
+It is important to note that this resolver specification is primarily intended for consumption by off-chain clients, such as SDKs and wallet software, rather than for direct on-chain smart contract integrations.
+
+---
+
+## Architecture
+
+The system comprises a single main smart contract:
+
+- **`L2Resolver`**: A contract that contains all data storage mechanisms, authorization logic for write operations, and the specific ENS resolution logic.
+
+### Design Considerations
+
+This single-contract approach offers simplicity in initial deployment as all data and logic are co-located. The storage structure and the initial set of functionalities are fixed upon deployment. This specification focuses on the self-contained L2Resolver contract. If further resolution paths or record types are desired, this contract can be wrapped by a newer one that extends the original interface. 
+
+---
+
+## Core Requirements
+
+The primary functionalities of this L2 resolver system are:
+
+1. **Domain to Chain ID Resolution**: Given an ENS name (e.g., `optimism.l2.eth`), resolve its EIP-7930 formatted chain identifier as `bytes` (representing the chain only, with `AddressLength = 0`) via `resolveChainId`.
+2. **Chain ID to Domain Resolution**: Given an EIP-7930 formatted chain identifier as `bytes` (with `AddressLength = 0`), resolve its primary associated ENS name (e.g., `optimism.l2.eth`) via `resolveName`.
+
+The L2 resolver system will operate on the designated ENS 2LD `l2.eth` using ENSIP-10 wildcard resolution. ENSIP-10 compliant clients, when resolving a name like `sub.l2.eth`, will first attempt to find a resolver for `sub.l2.eth`. If none is found, they will try the parent (`l2.eth`). If a resolver (this `L2Resolver` contract) is found for `l2.eth`, the client will then call the `resolve(bytes calldata name, bytes calldata data)` function on this resolver, passing the DNS-encoded original full name (e.g., `dnsencode("sub.l2.eth")`) as the `name` parameter.
+
+---
+
+## Contract Specification: `L2Resolver`
+
+This contract serves as the combined storage, authorization, and resolution layer.
+
+**State Variables:**
+
+- `mapping(bytes32 _node => mapping(string _key => bytes _data)) public records;`
+    - Stores arbitrary data for each ENS node.
+    - For domain-to-chain-identifier resolution, the `key` will be a pre-defined string (e.g., `CHAIN_IDENTIFIER_EIP7930_KEY`) and `data` will be the **raw EIP-7930 chain identifier `bytes`** (formatted with `AddressLength = 0`).
+    - For EIP-7930-chain-identifier-to-domain resolution (reverse lookup), the `REVERSE_LOOKUP_NODE` is used. The `key` is constructed by concatenating a prefix (e.g., `CHAIN_IDENTIFIER_EIP7930_KEY`) with the hexadecimal string representation of the `keccak256` hash of the EIP-7930 chain identifier `bytes`. The `data` stored is the **ABI-encoded human-readable ENS name string** (e.g., `abi.encode("optimism.l2.eth")`).
+
+**Constants:**
+
+- `bytes32 constant REVERSE_LOOKUP_NODE = bytes32(keccak256("reverse.chain.id.eip7930"));`
+    - A dedicated node hash for storing reverse lookup entries within this contract's `records` mapping.
+- `string constant CHAIN_IDENTIFIER_EIP7930_KEY = "chain.id.eip7930";`
+    - The key used in `records` to store the EIP-7930 chain identifier bytes for a forward resolution.
+
+**Key Functions:**
+
+- `function setRecord(bytes32 _node, string calldata _key, bytes calldata _value) external /* authorized */`
+    - Sets raw bytes for a given `node` and `key` in the `records` mapping.
+    - Authorization logic is implemented directly within this function (see below).
+    - Emits: `RecordSet(bytes32 indexed _node, string indexed _key, bytes _value)`
+    
+- `function getRecord(bytes32 _node, string calldata _key) external view returns (bytes memory)`
+    - Retrieves raw bytes for a given `node` and `key` from the `records` mapping. Returns empty `bytes` if the record is not found.
+    
+- `function resolveChainId(bytes32 _node) external view returns (bytes memory)`
+    - Retrieves the EIP-7930 formatted chain identifier (as `bytes`, with `AddressLength = 0`) for a given `node`.
+    - Implementation: Calls `this.getRecord(node, CHAIN_IDENTIFIER_EIP7930_KEY)`. Returns the raw `bytes` (which will be empty if the record is not found).
+    
+- `function resolveChainName(bytes calldata _chainIdBytes) external view returns (string memory)`
+    - Retrieves the primary human-readable ENS name string associated with a given EIP-7930 chain identifier (`bytes`, with `AddressLength = 0`).
+    - Assumes the input `chainIdBytes` is a correctly formatted EIP-7930 sequence.
+    - Off-chain tooling used to set reverse records should ensure canonical name formatting (e.g., lowercase, UTS#46 normalization) of the ENS name string.
+    - Implementation:
+        1. Hash the input: `bytes32 identifierHash = keccak256(chainIdBytes);`
+        2. Convert hash to hex string (conceptual step, e.g., using an internal `_bytes32ToHexString` helper). Let this be `hexIdentifierHash`.
+        3. Construct key: `string memory key = string.concat(CHAIN_IDENTIFIER_EIP7930_KEY, hexIdentifierHash);`
+        4. Retrieves data: `bytes memory data = this.getRecord(REVERSE_LOOKUP_NODE, key);`
+        5. Handles not found: `if (data.length == 0) { return ""; }`
+        6. Decodes and returns: `return abi.decode(data, (string));` (This will revert if `data` is not a valid ABI-encoded string).
+        
+
+**ENS Standard Functions:**
+
+- `function resolve(bytes calldata _name, bytes calldata _data) external view returns (bytes memory)`
+    - Implements the ENSIP-10 Extended Resolver interface. This function is called by ENS clients when this contract serves as a wildcard resolver (e.g., for `.l2.eth`).
+    - The `name` parameter is the DNS-encoded full version of the name being resolved (e.g., `dnsencode("optimism.l2.eth")`). This allows the resolver to inspect individual labels if needed for custom resolution logic beyond simple node-based lookups.
+    - The `data` parameter contains the ABI-encoded function selector and arguments for the actual data being requested, prepared by the client. For target functions that operate on an ENS node (like `resolveChainId(bytes32 node)`), the client calculates the `node` and includes it within this `data` payload.
+    - This function routes calls to other specific view functions on this resolver based on the function selector found in the `data` parameter.
+    - Currently supports routing to:
+        - `this.resolveChainId(node)`: If `data` contains the selector and ABI-encoded arguments for `resolveChainId(bytes32)`. The `node` argument is decoded by the resolver from the `data` parameter.
+        - `this.resolveName(chainIdentifierBytes)`: If `data` contains the selector and ABI-encoded arguments for `resolveName(bytes)`. The `chainIdentifierBytes` argument is decoded by the resolver from the `data` parameter.
+    - Returns the ABI-encoded result of the target function, or reverts if the `data` does not correspond to a supported function or if resolution fails.
+- `function supportsInterface(bytes4 interfaceID) external pure returns (bool)`
+    - Implements ENSIP-165. Returns `true` for:
+        - `0x01ffc9a7` (IERC165)
+        - `0x9061b923` (ENSIP-10 ExtendedResolver interface)
+
+---
+
+## EIP-7930 Chain Identifier Format
+
+Chain identifiers are stored and retrieved as EIP-7930 binary formatted `bytes`. For the purpose of this resolver (identifying a chain, not an address on a chain), these identifiers **MUST** be formatted with `AddressLength = 0`.
+
+The basic structure as per EIP-7930 v1 is:
+`Version (2 bytes) | ChainType (2 bytes) | ChainReferenceLength (1 byte) | ChainReference (variable) | AddressLength (1 byte, value 0x00)`
+
+- **Version**: `0x0001` (for v1).
+- **ChainType**: As defined in CAIP-350 (corresponds to a CAIP-2 namespace).
+- **ChainReferenceLength**: Length of `ChainReference`.
+- **ChainReference**: Binary representation of the chain ID within the `ChainType`'s namespace.
+- **AddressLength**: `0x00` (1 byte, value zero), indicating no address part.
+
+Clients (SDKs, wallets) interacting with this resolver are responsible for correctly constructing and parsing these EIP-7930 chain identifier `bytes`. The resolver contract treats this data as opaque byte sequences for storage and retrieval in forward lookups, and uses its hash for keying in reverse lookups.
+
+---
+
+## Authorization Model
+
+Write operations via `setRecord(bytes32 node, string calldata key, bytes calldata value)` must be permissioned. The authorization logic is implemented directly within the `L2Resolver` contract. It should generally follow the ENS ownership model:
+
+- To set a record for a specific `node` (e.g., `namehash("optimism.l2.eth")`), `msg.sender` must be the beneficial owner of that `node` (potentially resolved via `ENS.owner(node)` and checking against `INameWrapper.ownerOf(node)` if applicable) or an operator approved by the beneficial owner.
+- For non-registered 3LDs (wildcard scenario where `node` corresponds to something like `namehash("unregistered.l2.eth")`), `msg.sender` must be the beneficial owner of the parent domain (e.g., `l2.eth`) or their approved operator.
+- To set a reverse EIP-7930 chain identifier mapping (i.e., when `node == REVERSE_LOOKUP_NODE`), `msg.sender` must be a designated administrative entity (e.g., the owner of `l2.eth` or a specific authorized address). This control for `REVERSE_LOOKUP_NODE` writes is crucial for the integrity of reverse lookups.
+
+The `L2Resolver` will require a reference to the ENS Registry (and potentially INameWrapper) to implement this authorization logic.

--- a/specs/addresses/interop-sdk-spec.md
+++ b/specs/addresses/interop-sdk-spec.md
@@ -1,0 +1,631 @@
+# Interop SDK Tech Design
+
+# Introduction
+
+As part of the **Driving Interop** initiative, our goal is to reduce fragmentation across Ethereum chains by introducing a standard for interoperable addresses and enabling intents-based cross-chain interactions. To support this effort, we present the **Interop TypeScript SDK**, a modular and developer-friendly toolkit designed to simplify integration of interoperability primitives into decentralized applications.
+
+This SDK enables:
+
+- **Decoding** of human-readable interoperable addresses into binary format, following the [ERC-7930](https://ethereum-magicians.org/t/erc-7930-interoperable-addresses/23365) standard.
+- **Encoding** of interoperable addresses into UX-friendly formats suitable for frontend display.
+- **ENS resolution** support to allow interoperable addresses to include human-readable names.
+- **CrossChain** support enabling users to get quotes and submit intents across open-intent protocols on EVM chains.
+
+The technical design document that follows will outline the structure of the SDK, its core components, and how developers can leverage it to enhance cross-chain compatibility in their solutions.
+
+```mermaid
+---
+config:
+  class:
+    hideEmptyMembersBox: true
+  layout: dagre
+---
+classDiagram
+    SDK ..> InteropAddressModule
+    SDK ..> CrossChainModule
+    CrossChainModule o-- CrossChainProviderFactory
+    CrossChainProviderFactory o-- CrossChainProvider
+    CrossChainModule o-- CrossChainProviderExecutor
+    CrossChainModule o-- ParamsParser
+    SDK : + InteropAddressModule interopAddressUtils
+    SDK : + CrossChainModule crossChainUtils
+    CrossChainProvider <|-- Across
+    CrossChainProvider <|-- OIF1.0
+    CrossChainProvider <|-- SuperChainTokenBridge
+    ParamsParser <|-- InteropParamsParser
+    class InteropAddressModule {
+      + parseHumanReadable(humanReadableAddress: Hex) InteropAddress
+      + toHumanReadable(interopAddress: InteropAddress) Hex
+      + parseBinary(binaryAddress: Hex) InteropAddress
+      + toBinary(interopAddress: InteropAddress) Hex
+    }
+    class CrossChainModule {
+      + createCrossChainProvider(protocol, config, dependencies) CrossChainProvider
+      + createExecuter(providers: IntentProviders[]) CrossChainProviderExecutor
+    }
+    class CrossChainProviderFactory {
+      + build(protocolName: string) CrossChainProvider
+    }
+    class CrossChainProviderExecutor {
+      - providers: Map~protocolName, CrossChainProvider~
+      + new(providers:CrossChainProvider[], paramsParser: ParamsParser)
+      + getQuotes(params: GetQuoteParams) Quote[]
+      + execute(quote: Quote) Tx
+    }
+    class CrossChainProvider {
+      + getQuote(params: GetQuoteParams) Quote
+      + simulateOpen(quote: Quote) Tx
+    }
+    class ParamsParser {
+	    + parseGetQuoteParams<GetQuoteInputParams>(params: GetQuoteInputParams): GetQuoteParams
+	  }
+	  class InteropParamsParser {
+		  + parseGetQuoteParams(params: InteropInputParams): GetQuoteParams
+	  }
+```
+
+ 
+
+# In-Depth
+
+## Interoperable Addresses
+
+ERC-7390 introduces a new binary address format, the interoperable address (iAddress), which includes both a chain identifier and an account identifier.
+
+Our SDK is designed to implement functionalities related to the usage of these new iAddress, including
+
+- Serialize an iAddress into its binary representation ([ERC-7930](https://ethereum-magicians.org/t/erc-7930-interoperable-addresses/23365))
+- Parse a human readable address into an iAddress, [ERC-7828](https://ethereum-magicians.org/t/erc-7828-chain-specific-addresses-using-ens/21930) compatible
+- Serialize a human readable address into its binary representation
+
+```mermaid
+graph LR
+    A[humanReadable]
+    B[iAddress]
+    C[binaryRepresentation]
+
+    A -->|toIAddress| B
+    B -->|toBinary| C
+    C -->|toIAddress| B
+    B -->|toHumanReadable| A
+
+```
+
+This SDK is expected to implement all human-to-binary conversion paths to provide users with a complete set of functionalities.
+
+### The `InteropAddress` type
+
+We introduce a new type, the `InteropAddress` that will work as primary representation of an interop address on the SDK
+
+```tsx
+// Interop Address type definition
+export type InteropAddress = {
+    version: number;
+    chainType: Uint8Array;
+    chainReference: Uint8Array;
+    address: Uint8Array;
+};
+```
+
+Using `Uint8Array` instead of `string` for the fields in the `InteropAddress` type ensures that the data is represented in a raw, unambiguous binary format. This provides several advantages:
+
+- **Precision**: `Uint8Array` accurately represents each byte of data, avoiding any misinterpretation or alteration that might happen with character encodings in strings (e.g., UTF-8, UTF-16).
+- **Efficiency**: Binary data is more compact and faster to process than encoded string representations, especially in environments where performance and minimal overhead are critical.
+- **Interoperability**: `Uint8Array` ensures better compatibility with encoding and decoding libraries, which is important since different chains may use different encoding standards.
+- **Security**: Handling addresses and identifiers as raw bytes reduces the surface area for encoding-related vulnerabilities or errors when interfacing with blockchain systems or binary serialization formats.
+
+### The `InteropAddressFields` type
+
+```tsx
+export type interopAddressFields = {
+	version: number;
+	chainType: string // CAIP-2 namespace
+	chainReference: string, // chain reference
+	address: Address | `0x${string}` // chain specific account id
+}
+```
+
+Similar to `InteropAddress` type we have the `InteropAddressFields` which is a more readable representation of the `InteropAddress`
+
+## Human Readable Addresses
+
+We want to support as many different human readable addresses as posible without compromising the 1:1 relation with its binary representation.
+
+Supported address format should include:
+
+- ENS + Chain list (only evm compatible chains): `gori.eth@eth` , `gori.eth@oeth`
+- Raw Address + CAIP-2: `0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:1`
+- ENS + CAIP-2: `gori.eth@eip155:1`
+- Full Base64 interoperable address.
+
+[Human Readable Address Test Suite](https://www.notion.so/Human-Readable-Address-Test-Suite-1df9a4c092c780be8e47cfbfe6531184?pvs=21)
+
+### Valid ENS names
+
+ENS names must conform to the following syntax:
+
+```bash
+<domain> ::= <label> | <domain> "." <label>
+<label> ::= any valid string label per [UTS46](https://unicode.org/reports/tr46/)
+```
+
+The [IDNA mapping table](https://www.unicode.org/Public/idna/latest/) describes the full list of unicode characters and its UTS46 mapping with the **UseSTD3ASCIIRules** flag activated thus
+
+> These rules exclude ASCII characters outside the set consisting of A-Z, a-z, 0-9, and U+002D ( - ) HYPHEN-MINUS
+> 
+
+Therefore, an ENS name must not include an '@' character, making it safe to split on '@'.
+
+- [idna-uts46](https://www.npmjs.com/package/idna-uts46) library implements the UTS-46 specification
+    
+    ```jsx
+    import uts46 from 'idna-uts46';
+    
+    export function isValidEnsName(address) {
+      try {
+        uts46.toAscii(
+          address,
+          {
+            transitional: false,
+          useStd3ASCII: true,
+        }
+      );
+      return true;
+      } catch (error) {
+        return false;
+      }
+    }
+    
+    console.log(isValidEnsName('vitalik.eth')); // true
+    console.log(isValidEnsName('vita@lik.eth')); // false
+    ```
+    
+
+## CrossChain Framework
+
+We want to implement a framework to interact with different protocols(providers) which allow us to manage cross chain transactions.
+
+### Providers
+
+- **Open Intents Framework [**[OIF](https://www.openintents.xyz/)**]**
+
+An **intent** is a user’s *declaration of desired outcome, for example “I want to bridge X tokens from chain A for at least Y tokens in chain B.”*
+
+The Open Intents Framework is a public good initiative led by contributors from the EF, [Hyperlane](https://hyperlane.xyz/) and [Bootnode](https://www.bootnode.dev/) with the goal of bringing open and permissionless intents to all of Ethereum.
+
+### Methods
+
+Two methods defined for interactions with providers
+
+- **GetQuote(input, protocol): Quote**
+
+`GetQuote` will obtain a posible quote which fulfill the input entered by the dev in the specified protocol.
+
+- **SimulateOpen(Quote): void**
+
+`SimulateOpen` will return a transaction to execute the quote returned by the `GetQuote` function
+
+### Interfaces
+
+We will define some interfaces to GetQuote method
+
+```tsx
+export interface Input {
+	/// @dev The contract address of the source token on the origin chain
+	inputToken: string,
+	/// @dev The contract address of the destination token on the destination chain
+	outputToken: string,
+	/// @dev Chain id of the origin chain
+	inputChainId: string,
+	/// @dev Chain id of the destination chain
+	outputChainId: string,
+	/// @dev Amount of input token to move
+	inputAmount: string
+}
+
+export interface Quote {
+	/// The protocol used to get q
+	protocol: string,
+	/// The contract address of the source token on the origin chain
+	inputToken: string,
+	/// The contract address of the destination token on the destination chain
+	outputToken: string,
+	/// Chain id of the origin chain
+	inputChainId: string,
+	/// Chain id of the destination chain
+	outputChainId: string,
+	/// Amount of input token to move
+	inputAmount: string
+	/// Amount of output token the user will receive
+	outputAmount: string
+	/// Fee Amount
+	fee: string
+	/// Object OIF ready to pass to open or simulateOpen method
+	/// Folow Open Inten Framework standard
+	oifParams: {
+		fillDeadline: uint32;
+		orderDataType: uint32Array;
+		orderData: uint8Array;
+	}
+}
+
+function getQuote(input: Input, options: {protocol: Protocols}): Quote
+function simulateOpen(quote: Quote): TxToExecute
+```
+
+### Flow
+
+**Simple Flow using Provider Directly**
+
+```mermaid
+sequenceDiagram
+  Actor dev as Dev
+  participant sdk as Provider Factory
+  participant across as Across
+  participant rpc as RPC
+
+  dev ->>+ sdk: Get Provider: Across, Config
+  sdk ->>- dev: Across Provider
+  dev ->>+ across: Get Quote: Input
+  across ->>- dev: Quote
+
+  dev ->>+ across: Simulate Open: Quote, Across
+  across ->>- dev: Tx to Execute
+  
+  dev ->>+ rpc: Open: Tx to Execute
+  rpc ->>- dev: Result
+```
+
+**Advance Flow using Executor**
+
+```mermaid
+sequenceDiagram
+  Actor dev as Dev
+  participant sdk as Provider Factory
+  participant executor as Provider Executor
+  participant across as Across
+  participant sample as Sample Provider
+  participant rpc as RPC
+
+  dev ->>+ sdk: Get Provider: Across, Config
+  sdk ->>- dev: Across Provider
+  
+  dev ->>+ sdk: Get Provider: Sample, Config
+  sdk ->>- dev: Sample Provider
+  
+  dev ->>+ executor: GetExecutor: Sample, Across
+  executor ->>- dev: Excecutor
+  
+  dev ->>+ executor: Get Quotes: Input
+  
+  par Executor get quote from Across
+  executor ->>+ across: Get Quote: Input
+  across ->>- executor: Quote
+  and Executor get quote from Sample
+  executor ->>+ sample: Get Quote: Input
+  sample ->>- executor: Quote
+  end
+  
+  executor ->>- dev: AcrossQuote, SampleQuote
+  
+  alt Dev choose Across
+	  dev ->>+ executor: Execute: AcrossQuote
+	  executor ->>+ across: SimulateOpen: AcrossQuote.OpenParams
+	  across ->>+ executor: Tx to Execute
+	  executor ->>- dev: Tx to Execute
+	else Dev choose Sample
+		dev ->>+ executor: Execute: SampleQuote
+	  executor ->>+ sample: SimulateOpen: SampleQuote.OpenParams
+	  sample ->>+ executor: Tx to Execute
+	  executor ->>- dev: Tx to Execute
+  end
+  
+  dev ->>+ rpc: Open: Tx to Execute
+  rpc ->>- dev: Result
+```
+
+# API
+
+## Interoperable Addresses
+
+### **build(interopAddressFields) : InteropAddress**
+
+This method constructs a interop address based on the received params
+
+```tsx
+// build example
+const interopAddressFields = {
+	version: 1, // future versions of the interop address may change this param
+	chainType: "eip155" // CAIP-2 namespace
+	chainReference: "1", // chain reference
+	address: "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045" // chain specific account id
+}
+build(interopAddressFields)
+/* {
+	version: 1,
+	chainType: Uint8Array([0,0]),
+	chainReference: Uint8Array([1]),
+	address: Unit8Array([
+	  216, 218, 107, 242, 105, 100,
+	  175, 157, 126, 237, 158,   3,
+	  229,  52,  21, 211, 122, 169,
+	   96,  69
+	])
+} */
+```
+
+### **parseBinary(BinaryAddress) : InteropAddress**
+
+Takes a binary address and returns an interopAddress
+
+```tsx
+// parseBinary example
+const binaryAddress: BinaryAddress = "0x00010000010114D8DA6BF26964AF9D7EED9E03E53415D37AA96045"
+parseBinary(binaryAddress)
+/* {
+	version: 1,
+	chainType: Uint8Array([0,0]),
+	chainReference: Uint8Array([1]),
+	address: Unit8Array([
+	  216, 218, 107, 242, 105, 100,
+	  175, 157, 126, 237, 158,   3,
+	  229,  52,  21, 211, 122, 169,
+	   96,  69
+	])
+} */
+```
+
+### **toBinary(InteropAddress) : BinaryAddress**
+
+Takes an interop address and returns a binary representation
+
+```tsx
+// toBinary example
+const interopAddress = {
+	version: 1,
+	chainType: Uint8Array([0,0]),
+	chainReference: Uint8Array([1]),
+	address: Unit8Array([
+	  216, 218, 107, 242, 105, 100,
+	  175, 157, 126, 237, 158,   3,
+	  229,  52,  21, 211, 122, 169,
+	   96,  69
+	])
+}
+toBinary(interopAddress)
+/*
+0x00010000010114D8DA6BF26964AF9D7EED9E03E53415D37AA96045
+  ^^^^-------------------------------------------------- Version:              decimal 1
+      ^^^^---------------------------------------------- ChainType:            2 bytes of CAIP namespace
+          ^^-------------------------------------------- ChainReferenceLength: decimal 1
+            ^^------------------------------------------ ChainReference:       1 byte to store uint8(1)
+              ^^---------------------------------------- AddressLength:        decimal 20
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Address:              20 bytes of ethereum address
+*/
+```
+
+### **parseHumanReadable(HumanReadableAddress) : InteropAddress**
+
+Takes a human-readable address and returns an `InteropAddress`. This function also handles ENS name resolution if necessary.
+
+```tsx
+// parseHumanReadable example
+const humanReadableAddress = "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:1#4CA88C9C"
+parseHumanReadable(humanReadableAddress)
+/* {
+	version: 1,
+	chainType: Uint8Array([0,0]),
+	chainReference: Uint8Array([1]),
+	address: Unit8Array([
+	  216, 218, 107, 242, 105, 100,
+	  175, 157, 126, 237, 158,   3,
+	  229,  52,  21, 211, 122, 169,
+	   96,  69
+	])
+} */
+```
+
+### **toHumanReadable(interopAddress) : HumanReadableAddress**
+
+Takes an InteropAddress and returns a human readable address
+
+```tsx
+// toHumanReadable example
+const interopAddress = {
+	version: 1,
+	chainType: Uint8Array([0,0]),
+	chainReference: Uint8Array([1]),
+	address: Unit8Array([
+	  216, 218, 107, 242, 105, 100,
+	  175, 157, 126, 237, 158,   3,
+	  229,  52,  21, 211, 122, 169,
+	   96,  69
+	])
+}
+toHumanReadable(interopAddress)
+// 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045@eip155:1#4CA88C9C
+```
+
+### **getChainId(interopAddress) : Hex**
+
+Takes an interopAddress and returns the chainId, hex encoded. This should be used by the user to call contracts that do not support interop addresses.
+
+```tsx
+// getChainId example
+const interopAddress = {
+	version: 1,
+	chainType: Uint8Array([0,0]),
+	chainReference: Uint8Array([1]),
+	address: Unit8Array([
+	  216, 218, 107, 242, 105, 100,
+	  175, 157, 126, 237, 158,   3,
+	  229,  52,  21, 211, 122, 169,
+	   96,  69
+	])
+}
+getChainId(interopAddress)
+// 0x1
+```
+
+### **getAddress(interopAddress) : Hex**
+
+Takes an interopAddress and returns the hex encoded address string. This should be used by the user to call contracts that do not support interop addresses.
+
+```tsx
+// getAddress example
+const interopAddress = {
+	version: 1,
+	chainType: Uint8Array([0,0]),
+	chainReference: Uint8Array([1]),
+	address: Unit8Array([
+	  216, 218, 107, 242, 105, 100,
+	  175, 157, 126, 237, 158,   3,
+	  229,  52,  21, 211, 122, 169,
+	   96,  69
+	])
+}
+getAddress(interopAddress)
+// 0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045
+```
+
+### getQuote(input, options): Quote
+
+Get available quotes to deposit 100 USDC in optimism and receive USDC in arbitrum, using across
+
+```tsx
+const input = {
+	inputToken: "0x0b2c639c533813f4aa9d7837caf62653d097ff85" // USDC in Optimism
+	outputToken: "0xaf88d065e77c8cc2239327c5edb3a432268e5831" // USDC in Arbitrum
+	inputChainId: "10"
+	outputChainId: "42161"
+	inputAmount: "100"
+}
+
+const options = {
+	protocol: "across"
+}
+
+getQuote(input, options)
+/**
+	* Quote
+	  {
+	    inputToken: "0x0b2c639c533813f4aa9d7837caf62653d097ff85" // USDC in Optimism
+			outputToken: "0xaf88d065e77c8cc2239327c5edb3a432268e5831" // USDC in Arbitrum
+			inputChainId: "10"
+			outputChainId: "42161"
+			inputAmount: "100"
+			outputAmount: "98"
+			fee: "2"
+			oifParams: 
+				{
+				  fillDeadline: 152452345;
+					orderDataType: 324234234234;
+					orderData: [234, 24, 24, 52];
+			  }
+		}
+*/
+```
+
+### simulateOpen(quote): Tx
+
+When user want to execute the obtained quote, he will execute simulateOpen using the quote received, this will return a Tx ready to sign and send to the RPC
+
+```tsx
+const input = {
+	inputToken: "0x0b2c639c533813f4aa9d7837caf62653d097ff85" // USDC in Optimism
+	outputToken: "0xaf88d065e77c8cc2239327c5edb3a432268e5831" // USDC in Arbitrum
+	inputChainId: "10"
+	outputChainId: "42161"
+	inputAmount: "100"
+};
+
+const options = {
+	protocol: "across"
+};
+
+const quote = await getQuote(input, options);
+
+simulateOpen(quote);
+```
+
+# User stories
+
+## Interop Addresses
+
+**US1: Get checksum for a manually inserted address**
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Wallet
+    participant SDK
+
+    User->>Wallet: Inputs alice.eth@eip155:1
+    Wallet->>SDK: getChecksum
+    SDK-->>Wallet: Return checksum (ABCD1234)
+    Wallet->>User: Return alice.eth@eip155:1<hash>ABCD1234
+
+```
+
+**US2: Get binary representation of a human readable interop address**
+
+Rationale: I want to call a smart contract that supports 7930 interop addresses
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Wallet
+  participant SDK
+  participant ENSResolver
+
+  User->>Wallet: Input alice.eth@eip155:10<hash>ABCD1234
+  Wallet->>SDK: toBinary
+  SDK->>ENSResolver: Resolve ENS name alice.eth
+  ENSResolver-->>SDK: 0x123...789
+  SDK-->>Wallet: 0x0001000...789
+
+```
+
+**US3: Get human readable address from binary representation**
+
+```mermaid
+sequenceDiagram
+  participant ThirdPartyService
+  participant Wallet
+  participant SDK
+
+  ThirdPartyService-->>Wallet: Send binary interop address
+  Wallet->>SDK: toHumanReadable
+  SDK-->>Wallet: 0x123...789@eip155:10<hash>ABCD1234
+
+```
+
+**US4: Get canonical address**
+
+Rationale: I want to call a contract that do not support interop addresses
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Wallet
+  participant SDK
+
+  User->>Wallet: Input 0x123...789@eip155:10
+  Wallet->>SDK: GetAddress
+  SDK-->>Wallet: Returns address (0x123...789)
+```
+
+**US5: Get EVM chainId**
+
+Rationale: I want to call a contract that do not support interop addresses
+
+```mermaid
+sequenceDiagram
+  participant User
+  participant Wallet
+  participant SDK
+
+  User->>Wallet: Input alice.eth@eip155:10
+  Wallet->>SDK: GetChainId
+  SDK-->>Wallet: Returns chainId (0xA)
+```


### PR DESCRIPTION
This document analyzes the compatibility between ERC-7930 (binary interoperable addresses) and ERC-7828 (human readable addresses) with existing standards CAIP-10 and W3C Decentralized Identifiers (DID). While these standards share similar goals, they have compatibility challenges to consider.